### PR TITLE
Validate Addr, Exclude nodes with invalid ip address

### DIFF
--- a/src/ClusterNodesParser.h
+++ b/src/ClusterNodesParser.h
@@ -62,7 +62,7 @@ public:
             return false;
         }
 
-        const char* host = mAddr;
+        const char* host = mAddr.data();
         const char* port = strrchr(mAddr, ':');
         if (port) {
             std::string tmp;

--- a/src/ClusterNodesParser.h
+++ b/src/ClusterNodesParser.h
@@ -10,6 +10,8 @@
 #include "Buffer.h"
 #include "String.h"
 #include "Server.h"
+#include "arpa/inet.h"
+#include "string.h"
 
 class ClusterNodesParser
 {
@@ -54,6 +56,33 @@ public:
         begin = mSlotBegin;
         end = mSlotEnd;
         return begin >= 0 && begin < end;
+    }
+    bool validAddr() const {
+        if (mAddr.empty()) {
+            return false;
+        }
+
+        const char* host = "";
+        const char* port = strrchr(mAddr, ':');
+        if (port) {
+            std::string tmp;
+            tmp.append(mAddr, port - mAddr);
+            host = tmp.c_str();
+        }
+
+        char dst1[INET_ADDRSTRLEN];
+        int isIpv4 = inet_pton(AF_INET, host, dst1);
+        if (isIpv4) {
+            return true;
+        }
+
+        char dst2[INET6_ADDRSTRLEN];
+        int isIpv6 = inet_pton(AF_INET6, host, dst2);
+        if (isIpv6) {
+            return true;
+        }
+
+        return false;
     }
 private:
     enum State

--- a/src/ClusterNodesParser.h
+++ b/src/ClusterNodesParser.h
@@ -62,7 +62,7 @@ public:
             return false;
         }
 
-        const char* host = "";
+        const char* host = mAddr;
         const char* port = strrchr(mAddr, ':');
         if (port) {
             std::string tmp;

--- a/src/ClusterServerPool.cpp
+++ b/src/ClusterServerPool.cpp
@@ -101,7 +101,7 @@ void ClusterServerPool::handleResponse(Handler* h, ConnectConnection* s, Request
                      p.addr().data(),
                      p.flags().data(),
                      p.master().data());
-            if (p.addr().empty()) {
+            if (!p.validAddr()) {
                 logWarn("redis cluster nodes get node invalid %s %s %s %s",
                         p.nodeId().data(),
                         p.addr().data(),


### PR DESCRIPTION
**Problem Statement**

Recently we faced an issue with predixy during redis cluster scaling, where it was trying to connect to empty host.

**Incidents**

- PHP Redis client threw error message "read error on connection". 

- On checking predixy logs we found 
`2019-11-12 08:05:03.498123 W Handler.cpp:396 h 4 c 127.0.0.1:47187 430 handle event 1 exception Socket.cpp:120 invalid addr :6379:Name or service not known`
where addr is empty
 
<img width="1637" alt="live-predixy-error-logs" src="https://user-images.githubusercontent.com/16459106/68763104-a6d57480-063d-11ea-9d38-3d4daa2b6e2b.png">

- Predixy INFO command output
  <img width="630" alt="predixy-invalid-info" src="https://user-images.githubusercontent.com/16459106/68758924-bac8a880-0634-11ea-8569-c6b069e8d14e.png">
here one of the slaves are registered in the server pool even though it's host is invalid.

After replicating this issue on a test cluster, we found out that at some point "cluster nodes" is returning an invalid response where it doesn't have addr though the flag is valid (slave).
`D ClusterServerPool.cpp:103 redis cluster update parse node 52a144f80835728846892506bbd7942ac49bf09c :6379@1122 slave -`

<img width="1605" alt="Screenshot 2019-11-12 at 6 59 37 PM" src="https://user-images.githubusercontent.com/16459106/68758837-8f45be00-0634-11ea-9c45-9d4f5161ed2f.png">

**Solution**
- To handle this case this pull request adds address validation step to discard such invalid response from the redis.

Although the redis should respond according to the protocol, I think if the redis responds with an invalid format, predixy should do validations before inserting into the pool.
